### PR TITLE
Fix: fix " `doctype 5` is deprecated " error

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Open+Sans')


### PR DESCRIPTION
## Fixed a tiny error, by the way, thanks for your tutorial
### The error

![snip20140103_2](https://f.cloud.github.com/assets/3378031/1837143/a2f5c3a8-741f-11e3-8b69-10298e0629a6.png)
### After fix the error

![snip20140103_3](https://f.cloud.github.com/assets/3378031/1837144/ad10cd42-741f-11e3-83c9-aa0355050f8a.png)
